### PR TITLE
AddedProvider and Issuer details that were missing

### DIFF
--- a/src/main/java/org/forgerock/oauth/clients/oidc/SignInWithApple.java
+++ b/src/main/java/org/forgerock/oauth/clients/oidc/SignInWithApple.java
@@ -155,7 +155,9 @@ public class SignInWithApple extends AbstractSocialAuthLoginNode {
          * @return the provider.
          */
         @Attribute(order = 800)
-        String provider();
+        default String provider() {
+            return "Apple ID";
+        }
 
         /**
          * The authentication id key.
@@ -247,8 +249,9 @@ public class SignInWithApple extends AbstractSocialAuthLoginNode {
          * @return the issuer.
          */
         @Attribute(order = 1800)
-        String issuer();
-
+        default String issuer() {
+            return "https://appleid.apple.com";
+        }
         /**
          * The openid connect validation method.
          * @return the openid connect validation method.

--- a/src/main/java/org/forgerock/oauth/clients/oidc/SignInWithApple.java
+++ b/src/main/java/org/forgerock/oauth/clients/oidc/SignInWithApple.java
@@ -154,7 +154,7 @@ public class SignInWithApple extends AbstractSocialAuthLoginNode {
          * The provider. (useful if using IDM)
          * @return the provider.
          */
-        @Attribute(order = 800)
+        @Attribute(order = 800, validators = {RequiredValueValidator.class})
         default String provider() {
             return "Apple ID";
         }
@@ -248,10 +248,11 @@ public class SignInWithApple extends AbstractSocialAuthLoginNode {
          * The issuer. Must be specified to use mixup mitigation.
          * @return the issuer.
          */
-        @Attribute(order = 1800)
+        @Attribute(order = 1800, validators = {RequiredValueValidator.class})
         default String issuer() {
             return "https://appleid.apple.com";
         }
+        
         /**
          * The openid connect validation method.
          * @return the openid connect validation method.
@@ -260,7 +261,6 @@ public class SignInWithApple extends AbstractSocialAuthLoginNode {
         default SocialOpenIdConnectNode.OpenIDValidationMethod openIdValidationMethod() {
             return SocialOpenIdConnectNode.OpenIDValidationMethod.JWK_URL;
         }
-
 
         /**
          * The openid connect validation value.
@@ -273,7 +273,6 @@ public class SignInWithApple extends AbstractSocialAuthLoginNode {
         }
 
     }
-
 
     private static OAuthClientConfiguration getOAuthClientConfiguration(AppleConfig config) {
         AppleClientConfiguration.Builder<?, AppleClientConfiguration> builder =


### PR DESCRIPTION
Updated to add the missing Provider and Issuer details.

Tested with FRAM 6.5.1-eval and can confirm no issues now

helps resolve  https://github.com/ForgeRock/Sign-In-With-Apple/issues/1 and https://github.com/ForgeRock/Sign-In-With-Apple/issues/2